### PR TITLE
Parse server config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 data/
 data
 .DS_Store
+.vscode/

--- a/cmd/armeria/main.go
+++ b/cmd/armeria/main.go
@@ -7,8 +7,8 @@ import (
 
 func main() {
 	var configPath string
-	flag.StringVar(&configPath, "config", "no Path", "path to the config file")
-	flag.StringVar(&configPath, "c", "no Path", "path to the config file  (shorthand)")
+	flag.StringVar(&configPath, "config", "./config/development.yml", "path to the config file")
+	flag.StringVar(&configPath, "c", "./config/development.yml", "path to the config file  (shorthand)")
 
 	flag.Parse()
 

--- a/cmd/armeria/main.go
+++ b/cmd/armeria/main.go
@@ -6,12 +6,11 @@ import (
 )
 
 func main() {
-	publicPath := flag.String("public", "./client/dist", "public directory of client")
-	dataPath := flag.String("data", "./data", "data directory")
-	httpPort := flag.Int("port", 8081, "http listen port")
-	prodFlag := flag.Bool("prod", false, "sets production flag")
+	var configPath string
+	flag.StringVar(&configPath, "config", "no Path", "path to the config file")
+	flag.StringVar(&configPath, "c", "no Path", "path to the config file  (shorthand)")
 
 	flag.Parse()
 
-	armeria.Init(*prodFlag, *publicPath, *dataPath, *httpPort)
+	armeria.Init(configPath)
 }

--- a/config/development.yml
+++ b/config/development.yml
@@ -1,0 +1,4 @@
+public: "./client/dist"
+data: "data"
+port: 8081
+prod: false

--- a/config/development.yml
+++ b/config/development.yml
@@ -1,4 +1,4 @@
-public: "./client/dist"
-data: "data"
-port: 8081
-prod: false
+dataPath: "./data"
+httpPort: 8081
+production: false
+publicPath: "./client/dist"

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -2,6 +2,7 @@ package armeria
 
 import (
 	"io/ioutil"
+	"log"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
@@ -27,9 +28,7 @@ func readConfigFile(filePath string) []byte {
 
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		Armeria.log.Debug("config file read error",
-			zap.Error(err),
-		)
+		log.Fatalf("Error reading config file: %s", err)
 	}
 	return data
 }

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -15,8 +15,6 @@ type config struct {
 	DataPath   string `yaml:"dataPath"`
 }
 
-//TODO check file exists before reading
-
 func parseConfigFile(filePath string) config {
 	data := readConfigFile(filePath)
 	c := unmarshalConfig(data)

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -27,7 +27,7 @@ func readConfigFile(filePath string) []byte {
 
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		Armeria.log.Debug("config read error",
+		Armeria.log.Debug("config file read error",
 			zap.Error(err),
 		)
 	}

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -22,7 +22,6 @@ func parseConfigFile(filePath string) config {
 }
 
 func readConfigFile(filePath string) []byte {
-
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		log.Fatalf("Error reading config file: %s", err)

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"log"
 
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 )
 
@@ -35,9 +34,7 @@ func unmarshalConfig(data []byte) config {
 	c := config{}
 	err := yaml.Unmarshal([]byte(data), &c)
 	if err != nil {
-		Armeria.log.Debug("Unmarshaling error",
-			zap.Error(err),
-		)
+		log.Fatalf("Error Unmarshalling config: %s", err)
 	}
 	return c
 }

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -1,0 +1,47 @@
+package armeria
+
+import (
+	"io/ioutil"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+//Config struct
+type config struct {
+	Port   int
+	Public string
+	Prod   bool
+	Data   string
+}
+
+//TODO check file exists before reading
+
+func parseConfigFile(filePath string) config {
+	data := readConfigFile(filePath)
+	c := unmarshalConfig(data)
+	return c
+
+}
+
+func readConfigFile(filePath string) []byte {
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		Armeria.log.Debug("config read error",
+			zap.Error(err),
+		)
+	}
+	return data
+}
+
+func unmarshalConfig(data []byte) config {
+	c := config{}
+	err := yaml.Unmarshal([]byte(data), &c)
+	if err != nil {
+		Armeria.log.Debug("Unmarshaling error",
+			zap.Error(err),
+		)
+	}
+	return c
+}

--- a/internal/pkg/armeria/config.go
+++ b/internal/pkg/armeria/config.go
@@ -7,12 +7,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-//Config struct
 type config struct {
-	Port   int
-	Public string
-	Prod   bool
-	Data   string
+	HTTPPort   int    `yaml:"httpPort"`
+	PublicPath string `yaml:"publicPath"`
+	Production bool   `yaml:"production"`
+	DataPath   string `yaml:"dataPath"`
 }
 
 //TODO check file exists before reading

--- a/internal/pkg/armeria/state.go
+++ b/internal/pkg/armeria/state.go
@@ -29,7 +29,9 @@ var (
 )
 
 func Init(fileLocation string) {
+
 	c := parseConfigFile(fileLocation)
+
 	Armeria = &GameState{
 		production:       c.Production,
 		publicPath:       c.PublicPath,

--- a/internal/pkg/armeria/state.go
+++ b/internal/pkg/armeria/state.go
@@ -28,12 +28,13 @@ var (
 	Armeria *GameState
 )
 
-func Init(production bool, publicPath string, dataPath string, httpPort int) {
+func Init(fileLocation string) {
+	c := parseConfigFile(fileLocation)
 	Armeria = &GameState{
-		production:       production,
-		publicPath:       publicPath,
-		dataPath:         dataPath,
-		objectImagesPath: dataPath + "/object-images",
+		production:       c.Production,
+		publicPath:       c.PublicPath,
+		dataPath:         c.DataPath,
+		objectImagesPath: c.DataPath + "/object-images",
 	}
 
 	logger, err := zap.NewDevelopment()
@@ -53,7 +54,7 @@ func Init(production bool, publicPath string, dataPath string, httpPort int) {
 	Armeria.setupPeriodicSaves()
 
 	RegisterGameCommands()
-	InitWeb(httpPort)
+	InitWeb(c.HTTPPort)
 }
 
 func (gs *GameState) setupGracefulExit() {


### PR DESCRIPTION
Config File path can now be passed in as CLI argument and the config is parsed forom that file.
Note: If no config file is passed through the CLI a default path will be chosen which points to the development config file.
This issue fixes issue number 26 (Create a YAML config file for the server)